### PR TITLE
Avoid undefined behaviour

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -134,8 +134,10 @@ struct Scanner {
         buffer[i++] = num_emphasis_delimiters_left;
         size_t blocks_count = open_blocks.size();
         if (blocks_count > UINT8_MAX - i) blocks_count = UINT8_MAX - i;
-        memcpy(&buffer[i], open_blocks.data(), blocks_count);
-        i += blocks_count;
+        if (blocks_count > 0) {
+            memcpy(&buffer[i], open_blocks.data(), blocks_count);
+            i += blocks_count;
+        }
         return i;
     }
 
@@ -157,7 +159,9 @@ struct Scanner {
             num_emphasis_delimiters_left = buffer[i++];
             size_t blocks_count = length - i;
             open_blocks.resize(blocks_count);
-            memcpy(open_blocks.data(), &buffer[i], blocks_count);
+            if (blocks_count > 0) {
+                memcpy(open_blocks.data(), &buffer[i], blocks_count);
+            }
         }
     }
 


### PR DESCRIPTION
memcpy() with a null destination or source is undefined.  

I realise that this parser is work in progress, but I couldn't resist pointing the fuzzer at it to see what it had to say.  This was the first thing that it found; so I thought I'd send you an MR.

The other that I have discovered is that the following file causes an infinite loop:

<pre>
```
</pre>

that's three backticks and - importantly - no final new line character (the file contains just three bytes).

Probably it doesn't make much sense for me to be fuzzing this in its current state so I'll stop now.  But I'd encourage you to set it up for yourself: it's not so hard and, as above, it'll find bugs!