### PR TITLE
Compile external scanner in rust build script

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -13,19 +13,9 @@ fn main() {
     // If your language uses an external scanner written in C,
     // then include this block of code:
 
-    /*
-    let scanner_path = src_dir.join("scanner.c");
-    c_config.file(&scanner_path);
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
-
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
-    // If your language uses an external scanner written in C++,
-    // then include this block of code:
-
-    /*
     let mut cpp_config = cc::Build::new();
     cpp_config.cpp(true);
     cpp_config.include(&src_dir);
@@ -36,5 +26,4 @@ fn main() {
     cpp_config.file(&scanner_path);
     cpp_config.compile("scanner");
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 }


### PR DESCRIPTION
Hi, awesome work on this parser!

I was just trying it out on a rust project and I noticed that the build script hadn't yet been set up to work in the rust crate (the CLI doesn't auto-detect that you're using an external scanner, so you have to manually uncomment some code). This PR just uncomments the relevant lines, enabling the project to be consumed directly from rust. Thanks!