### PR TITLE
SPM support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 target
+/.build

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,44 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "TreeSitterMarkdown",
+    platforms: [.macOS(.v10_13), .iOS(.v11)],
+    products: [
+        .library(name: "TreeSitterMarkdown", targets: ["TreeSitterMarkdown", "TreeSitterMarkdownInline"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "TreeSitterMarkdown",
+                path: "tree-sitter-markdown",
+                exclude: [
+                    "corpus",
+                    "grammar.js",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.cc",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")]),
+        .target(name: "TreeSitterMarkdownInline",
+                path: "tree-sitter-markdown-inline",
+                exclude: [
+                    "corpus",
+                    "grammar.js",
+                ],
+                sources: [
+                    "src/parser.c",
+                    "src/scanner.cc",
+                ],
+                resources: [
+                    .copy("queries")
+                ],
+                publicHeadersPath: "bindings/swift",
+                cSettings: [.headerSearchPath("src")])
+    ]
+)

--- a/bindings/swift/notes.txt
+++ b/bindings/swift/notes.txt
@@ -1,0 +1,6 @@
+It would be more consistent to put Swift binding C headers here. But, that will not work because of two SPM limitations:
+
+- Each target must have a unique directory
+- C headers must be within that directory
+
+Building both parsers as one target is possible, but would result in naming issue with the copied queries. If one day either of those limitations is removed, the per-parser bindings can be moved here.

--- a/tree-sitter-markdown-inline/bindings/swift/TreeSitterMarkdownInline/markdown_inline.h
+++ b/tree-sitter-markdown-inline/bindings/swift/TreeSitterMarkdownInline/markdown_inline.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_MARKDOWN_INLINE_H_
+#define TREE_SITTER_MARKDOWN_INLINE_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_markdown_inline();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_MARKDOWN_INLINE_H_

--- a/tree-sitter-markdown/bindings/swift/TreeSitterMarkdown/markdown.h
+++ b/tree-sitter-markdown/bindings/swift/TreeSitterMarkdown/markdown.h
@@ -1,0 +1,16 @@
+#ifndef TREE_SITTER_MARKDOWN_H_
+#define TREE_SITTER_MARKDOWN_H_
+
+typedef struct TSLanguage TSLanguage;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern TSLanguage *tree_sitter_markdown();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TREE_SITTER_MARKDOWN_H_


### PR DESCRIPTION
This adds Swift bindings.

Unfortunately, due to the two parsers and some limitations with Swift's build system, I had put some files within each parser's directory. This keeps the user's experience the same as other SPM-ified parsers they have used. But, if that feels to invasive, I can definitely change it.