### PR TITLE
Typo in capture name

### DIFF
--- a/tree-sitter-markdown/queries/injections.scm
+++ b/tree-sitter-markdown/queries/injections.scm
@@ -5,7 +5,7 @@
     (language) @injection.language)
   (code_fence_content) @injection.content)
 
-((html_block) @injction.content (#set! injection.language "html"))
+((html_block) @injection.content (#set! injection.language "html"))
 
 (document . (section . (thematic_break) (_) @injection.content (thematic_break)) (#set! injection.language "yaml"))
 ((inline) @injection.content (#set! injection.language "markdown_inline"))


### PR DESCRIPTION
Was just checking out the injection definitions, and noticed a typo in a capture name!