### PR TITLE
Capture plus and minus metadata injections

### DIFF
--- a/tree-sitter-markdown/queries/injections.scm
+++ b/tree-sitter-markdown/queries/injections.scm
@@ -1,5 +1,3 @@
-; From nvim-treesitter/nvim-treesitter
-
 (fenced_code_block
   (info_string
     (language) @injection.language)
@@ -8,5 +6,7 @@
 ((html_block) @injection.content (#set! injection.language "html"))
 
 (document . (section . (thematic_break) (_) @injection.content (thematic_break)) (#set! injection.language "yaml"))
-((inline) @injection.content (#set! injection.language "markdown_inline"))
 
+([(minus_metadata) (plus_metadata)] @injection.content (#set! injection.language "yml"))
+
+((inline) @injection.content (#set! injection.language "markdown_inline"))


### PR DESCRIPTION
While testing out the injections, I noticed that plus/minus metadata wasn't being correctly captured.

I also removed the mention of nvim-treesitter, because at this point, it has diverged. They've done truly amazing work with tree-sitter, but I really feel like the parser data should live with the parsers. When possible, one source of truth just makes sense.