### PR TITLE
Fix comment about parenthesis omission

### DIFF
--- a/tree-sitter-markdown-inline/queries/highlights.scm
+++ b/tree-sitter-markdown-inline/queries/highlights.scm
@@ -29,7 +29,7 @@
   (hard_line_break)
 ] @string.escape
 
-; "(" not part of query because of
+; ")" not part of query because of
 ; https://github.com/nvim-treesitter/nvim-treesitter/issues/2206
 ; TODO: Find better fix for this
 (image ["!" "[" "]" "("] @punctuation.delimiter)


### PR DESCRIPTION
Update the comment about not including closing parens in the punctuation.delimiter query to cite the correct character.