### PR TITLE
Add Swift accessors for scm resources

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "TreeSitterMarkdown",
     platforms: [.macOS(.v10_13), .iOS(.v11)],
     products: [
-        .library(name: "TreeSitterMarkdown", targets: ["TreeSitterMarkdown", "TreeSitterMarkdownInline"]),
+        .library(name: "TreeSitterMarkdown", targets: ["TreeSitterMarkdown", "TreeSitterMarkdownInline", "TreeSitterMarkdownQueries", "TreeSitterMarkdownInlineQueries"]),
     ],
     dependencies: [],
     targets: [
@@ -20,11 +20,21 @@ let package = Package(
                     "src/parser.c",
                     "src/scanner.cc",
                 ],
-                resources: [
-                    .copy("queries")
-                ],
                 publicHeadersPath: "bindings/swift",
                 cSettings: [.headerSearchPath("src")]),
+        .target(name: "TreeSitterMarkdownQueries",
+                path: "tree-sitter-markdown",
+                exclude: [
+                    "corpus",
+                    "grammar.js",
+                    "src",
+                ],
+                sources: [
+                    "bindings/swift/TreeSitterMarkdownQueries/Query.swift",
+                ],
+                resources: [
+                    .process("queries")
+                ]),
         .target(name: "TreeSitterMarkdownInline",
                 path: "tree-sitter-markdown-inline",
                 exclude: [
@@ -35,10 +45,20 @@ let package = Package(
                     "src/parser.c",
                     "src/scanner.cc",
                 ],
-                resources: [
-                    .copy("queries")
-                ],
                 publicHeadersPath: "bindings/swift",
-                cSettings: [.headerSearchPath("src")])
+                cSettings: [.headerSearchPath("src")]),
+        .target(name: "TreeSitterMarkdownInlineQueries",
+                path: "tree-sitter-markdown-inline",
+                exclude: [
+                    "corpus",
+                    "grammar.js",
+                    "src",
+                ],
+                sources: [
+                    "bindings/swift/TreeSitterMarkdownInlineQueries/Query.swift",
+                ],
+                resources: [
+                    .process("queries")
+                ]),
     ]
 )

--- a/tree-sitter-markdown-inline/bindings/swift/TreeSitterMarkdownInlineQueries/Query.swift
+++ b/tree-sitter-markdown-inline/bindings/swift/TreeSitterMarkdownInlineQueries/Query.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public enum Query {
+    public static var highlightsFileURL: URL {
+        return url(named: "highlights")
+    }
+
+    public static var injectionsFileURL: URL {
+        return url(named: "injections")
+    }
+}
+
+private extension Query {
+    static func url(named filename: String) -> URL {
+        return Bundle.module.url(forResource: filename, withExtension: "scm")!
+    }
+}

--- a/tree-sitter-markdown/bindings/swift/TreeSitterMarkdownQueries/Query.swift
+++ b/tree-sitter-markdown/bindings/swift/TreeSitterMarkdownQueries/Query.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public enum Query {
+    public static var highlightsFileURL: URL {
+        return url(named: "highlights")
+    }
+
+    public static var injectionsFileURL: URL {
+        return url(named: "injections")
+    }
+}
+
+private extension Query {
+    static func url(named filename: String) -> URL {
+        return Bundle.module.url(forResource: filename, withExtension: "scm")!
+    }
+}


### PR DESCRIPTION
This PR updates the Swift bindings and moves the resources to their own targets that get bundled up in the library product. Before this, we had to do this to access the files:

```
let url = Bundle.main
              .resourceURL?
              .appendingPathComponent("TreeSitterSwift_TreeSitterSwift.bundle")
              .appendingPathComponent("Contents/Resources/queries/highlights.scm")
```

Whereas now we can access them like this:

```
let markdownHighlights = TreeSitterMarkdownQueries.Query.highlightsFileURL
let markdownInlineHighlights = TreeSitterMarkdownQueries.Query.highlightsFileURL
```

This is a breaking change for anyone depending on the existing structure but I think it's a pretty big quality-of-life improvement (and has yet to make it in to an official release). Shout out to Simon Støvring who did things this way in his [TreeSitterLanguages package](https://github.com/simonbs/TreeSitterLanguages/tree/main/Sources/TreeSitterMarkdownQueries).