### PR TITLE
fix: use `_Static_assert`, not `static_assert`

### DIFF
--- a/tree-sitter-markdown/src/scanner.c
+++ b/tree-sitter-markdown/src/scanner.c
@@ -1557,7 +1557,7 @@ void *tree_sitter_markdown_external_scanner_create() {
     Scanner *s = (Scanner *)malloc(sizeof(Scanner));
     s->open_blocks.items = (Block *)calloc(1, sizeof(Block));
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
-    static_assert(ATX_H6_MARKER == ATX_H1_MARKER + 5, "");
+    _Static_assert(ATX_H6_MARKER == ATX_H1_MARKER + 5, "");
 #else
     assert(ATX_H6_MARKER == ATX_H1_MARKER + 5);
 #endif


### PR DESCRIPTION
According to https://en.cppreference.com/w/c/language/_Static_assert in C11,
one should use `_Static_assert`, not `static_assert` for better compatibility.

`static_assert` can make neovim crash if the treesitter parser is
built against a lower version of stdc libs. (nvim-treesitter/nvim-treesitter#5623)

Similar fix to https://github.com/tree-sitter/tree-sitter-python/pull/235.