### PR TITLE
chore: fix npm publish warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "@tree-sitter-grammars/tree-sitter-markdown",
   "version": "0.2.1",
   "description": "Markdown grammar for tree-sitter",
-  "repository": "github:tree-sitter-grammars/tree-sitter-markdown",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tree-sitter-grammars/tree-sitter-markdown.git"
+  },
   "author": "MDeiml (https://github.com/MDeiml)",
   "license": "MIT",
   "main": "bindings/node",


### PR DESCRIPTION
# Fix errors in npm publish script

This fixes some errors I found using the following command:

```sh
$ npm publish --dry-run
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository" was changed from a string to an object
npm WARN publish "repository.url" was normalized to "git+https://github.com/tree-sitter-grammars/tree-sitter-markdown.git"
npm notice
npm notice 📦  @tree-sitter-grammars/tree-sitter-markdown@0.2.1
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 4.6kB README.md
npm notice 582B  binding.gyp
npm notice 1.0kB bindings/node/binding.cc
npm notice 479B  bindings/node/index.d.ts
npm notice 328B  bindings/node/index.js
npm notice 38B   bindings/node/inline.js
npm notice 1.8kB package.json
npm notice === Tarball Details ===
npm notice name:          @tree-sitter-grammars/tree-sitter-markdown
npm notice version:       0.2.1
npm notice filename:      tree-sitter-grammars-tree-sitter-markdown-0.2.1.tgz
npm notice package size:  4.1 kB
npm notice unpacked size: 9.9 kB
npm notice shasum:        8a721c25ecafe065004b64bb57a2b0402afee910
npm notice integrity:     sha512-FeJnVcDba5dpQ[...]EjLn/FFF3edQw==
npm notice total files:   8
npm notice
npm WARN This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
+ @tree-sitter-grammars/tree-sitter-markdown@0.2.1
```

I ran `npm pkg fix` to fix the errors. The command is not shown here because it did not produce any output.
