### PR TITLE
chore: include the grammar files in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,11 @@
     "markdown"
   ],
   "files": [
-    "grammar.js",
+    "common/grammar.js",
+    "tree-sitter-markdown/grammar.js",
+    "tree-sitter-markdown/src/grammar.json",
+    "tree-sitter-markdown-inline/grammar.js",
+    "tree-sitter-markdown-inline/src/grammar.json",
     "binding.gyp",
     "prebuilds/**",
     "bindings/node/*",


### PR DESCRIPTION
# Include the grammar files in the npm package

I started to work on a parser for a markdown derived language used by [presenterm](https://github.com/mfontanini/presenterm). I am new to tree-sitter parser development, but I think what I want to do is reuse the grammar from this parser and essentially add a couple of things on top.

Currently, the grammar is not included in the npm package, so I can't extend it. I think this is because the `files` field in the `package.json` file does not include the grammar files.

The current contents of the package can be seen here:

https://www.npmjs.com/package/@tree-sitter-grammars/tree-sitter-markdown/v/0.2.1?activeTab=code

## The fix

To fix this, I added the grammar files to the `files` field in the `package.json` file.

npm publish before the changes:

```sh
$ npm publish --dry-run
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository" was changed from a string to an object
npm WARN publish "repository.url" was normalized to "git+https://github.com/tree-sitter-grammars/tree-sitter-markdown.git"
npm notice
npm notice 📦  @tree-sitter-grammars/tree-sitter-markdown@0.2.1
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 4.6kB README.md
npm notice 582B  binding.gyp
npm notice 1.0kB bindings/node/binding.cc
npm notice 479B  bindings/node/index.d.ts
npm notice 328B  bindings/node/index.js
npm notice 38B   bindings/node/inline.js
npm notice 1.8kB package.json
npm notice === Tarball Details ===
npm notice name:          @tree-sitter-grammars/tree-sitter-markdown
npm notice version:       0.2.1
npm notice filename:      tree-sitter-grammars-tree-sitter-markdown-0.2.1.tgz
npm notice package size:  4.1 kB
npm notice unpacked size: 9.9 kB
npm notice shasum:        8a721c25ecafe065004b64bb57a2b0402afee910
npm notice integrity:     sha512-FeJnVcDba5dpQ[...]EjLn/FFF3edQw==
npm notice total files:   8
npm notice
npm WARN This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
+ @tree-sitter-grammars/tree-sitter-markdown@0.2.1
```

npm publish after the changes:

```sh
npm notice
npm notice 📦  @tree-sitter-grammars/tree-sitter-markdown@0.2.1
npm notice === Tarball Contents ===
npm notice 1.1kB   LICENSE
npm notice 4.6kB   README.md
npm notice 582B    binding.gyp
npm notice 1.0kB   bindings/node/binding.cc
npm notice 479B    bindings/node/index.d.ts
npm notice 328B    bindings/node/index.js
npm notice 38B     bindings/node/inline.js
npm notice 5.6kB   common/grammar.js
npm notice 2.0kB   package.json
npm notice 22.6kB  tree-sitter-markdown-inline/grammar.js
npm notice 197.3kB tree-sitter-markdown-inline/src/grammar.json
npm notice 25.6kB  tree-sitter-markdown/grammar.js
npm notice 159.4kB tree-sitter-markdown/src/grammar.json
npm notice === Tarball Details ===
npm notice name:          @tree-sitter-grammars/tree-sitter-markdown
npm notice version:       0.2.1
npm notice filename:      tree-sitter-grammars-tree-sitter-markdown-0.2.1.tgz
npm notice package size:  42.2 kB
npm notice unpacked size: 420.7 kB
npm notice shasum:        44164c19d37b0356c6082ce69709dac793990865
npm notice integrity:     sha512-QyVX78sTNjdas[...]X/Wt0ime1PXgw==
npm notice total files:   13
npm notice
npm WARN This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
+ @tree-sitter-grammars/tree-sitter-markdown@0.2.1
```
