### PR TITLE
docs: contribution instructions teach how to run tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,16 @@ Before submitting any code please check the following:
 * You deleted any auto-generated bindings and files for debugging purposes
   like `log.html`
 
+## Tests
+
+To run the tests, first install the development dependencies (see above), then
+execute:
+
+```sh
+ALL_EXTENSIONS=1 npm run build
+npm test
+```
+
 [issue]: https://github.com/tree-sitter-grammars/tree-sitter-markdown/issues/new
 [pull request]: https://github.com/tree-sitter-grammars/tree-sitter-markdown/compare
 [gfm]: https://github.github.com/gfm/


### PR DESCRIPTION
Fixes
https://github.com/tree-sitter-grammars/tree-sitter-markdown/issues/136

^it looks like they ran into the same issue as me. It was difficult to figure out how to correctly run the tests, and I thought they are broken.

I found out the correct way to run them by meticulously reading these
- https://github.com/tree-sitter-grammars/tree-sitter-markdown/actions/runs/8272019685/job/22633037137
- https://github.com/tree-sitter/parser-test-action/blob/master/action.yml