### PR TITLE
chore: fix not being able to discard changes to .png files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text eol=lf
+*.png -text
 
 */src/*.json linguist-generated
 */src/parser.c linguist-generated


### PR DESCRIPTION
After cloning on osx, a file in this repository is constantly reported as having been modified.

Demo:


https://github.com/tree-sitter-grammars/tree-sitter-markdown/assets/300791/ffba7783-ad1a-453e-bcdd-b8cd04400216

ChatGPT thinks this is caused by `.gitattributes` specifying all files to be text files with `lf` line endings:

![image](https://github.com/tree-sitter-grammars/tree-sitter-markdown/assets/300791/2efaea8a-0ea5-47c5-a933-d107ded88f2b)
