### PR TITLE
Fix filename of common/common.js in package.json that breaks the node package after rename.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "tree-sitter-*/grammar.js",
     "tree-sitter-*/queries/*",
     "tree-sitter-*/src/**",
-    "common/grammar.js",
+    "common/common.js",
     "common/html_entities.json"
   ],
   "dependencies": {


### PR DESCRIPTION
The file was renamed in cf9a73c131723b29654b6e3b25931b8c5944eef9, but the change was not reflected in `package.json`.