### PR TITLE
injections.scm: TOML +++ metadata frontmatter support

### DIFF
--- a/tree-sitter-markdown/queries/injections.scm
+++ b/tree-sitter-markdown/queries/injections.scm
@@ -7,6 +7,8 @@
 
 (document . (section . (thematic_break) (_) @injection.content (thematic_break)) (#set! injection.language "yaml"))
 
-([(minus_metadata) (plus_metadata)] @injection.content (#set! injection.language "yml"))
+((minus_metadata) @injection.content (#set! injection.language "yaml"))
+
+((plus_metadata) @injection.content (#set! injection.language "toml"))
 
 ((inline) @injection.content (#set! injection.language "markdown_inline"))


### PR DESCRIPTION
The convention for front matter seems to be that `---` is generally yaml while `+++` is TOML. 
 At least that's how [hugo front-matter](https://gohugo.io/content-management/front-matter/) and [Zola front-matter](https://www.getzola.org/documentation/content/page/#front-matter) work.

This makes `plus_metadata` a TOML injection instead of YAML.

See also:
- https://github.com/zed-industries/zed/pull/21503

Zed uses a slightly different way of handling queries, so what is here is untested, but matches the style of the previous line.