### PR TITLE
Require tree-sitter.json for Successful Tree-Sitter Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "binding.gyp",
     "prebuilds/**",
     "bindings/node/*",
+    "tree-sitter.json",
     "tree-sitter-*/grammar.js",
     "tree-sitter-*/queries/*",
     "tree-sitter-*/src/**",


### PR DESCRIPTION
Ensures `tree-sitter.json` is present for the build.  
Without it, the following may fail:  

```bash
npm i -D @tree-sitter-grammars/tree-sitter-markdown
tree-sitter build --wasm node_modules/@tree-sitter-grammars/tree-sitter-markdown/tree-sitter-markdown
```