### PR TITLE
Upgrade to tree-sitter 0.26 API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,10 @@ path = "bindings/rust/lib.rs"
 
 [dependencies]
 tree-sitter-language = "0.1"
-tree-sitter = { version = "0.24", optional = true }
+tree-sitter = { version = "0.26", optional = true }
 
 [dev-dependencies]
-tree-sitter = "0.24.3"
+tree-sitter = "0.26"
 
 [build-dependencies]
 cc = "1.1.22"

--- a/bindings/rust/parser.rs
+++ b/bindings/rust/parser.rs
@@ -272,7 +272,7 @@ impl MarkdownParser {
         parser
             .set_language(block_language)
             .expect("Could not load block grammar");
-        let block_tree = parser.parse_with(callback, old_tree.map(|tree| &tree.block_tree))?;
+        let block_tree = parser.parse_with_options(callback, old_tree.map(|tree| &tree.block_tree), None)?;
         let (mut inline_trees, mut inline_indices) = if let Some(old_tree) = old_tree {
             let len = old_tree.inline_trees.len();
             (Vec::with_capacity(len), HashMap::with_capacity(len))
@@ -322,9 +322,10 @@ impl MarkdownParser {
             }
             ranges.push(range);
             parser.set_included_ranges(&ranges).ok()?;
-            let inline_tree = parser.parse_with(
+            let inline_tree = parser.parse_with_options(
                 callback,
                 old_tree.and_then(|old_tree| old_tree.inline_trees.get(i)),
+                None,
             )?;
             inline_trees.push(inline_tree);
             inline_indices.insert(node.id(), i);


### PR DESCRIPTION
- Update tree-sitter dependency from 0.24 to 0.26
- Update Rust bindings: parse_with → parse_with_options (third argument)