### PR TITLE
fix: Allow ordered lists to start from any number

### DIFF
--- a/tree-sitter-markdown/src/scanner.c
+++ b/tree-sitter-markdown/src/scanner.c
@@ -735,7 +735,7 @@ static bool parse_ordered_list_marker(Scanner *s, TSLexer *lexer,
          valid_symbols[LIST_MARKER_PARENTHESIS_DONT_INTERRUPT] ||
          valid_symbols[LIST_MARKER_DOT_DONT_INTERRUPT])) {
         size_t digits = 1;
-        bool dont_interrupt = lexer->lookahead != '1';
+        bool dont_interrupt = !isdigit(lexer->lookahead);
         advance(s, lexer);
         while (isdigit(lexer->lookahead)) {
             dont_interrupt = true;

--- a/tree-sitter-markdown/test/corpus/issues.txt
+++ b/tree-sitter-markdown/test/corpus/issues.txt
@@ -114,3 +114,58 @@ globalNS.method1(5, 10);
       (fenced_code_block_delimiter))
     (paragraph
       (inline))))
+
+================================================================================
+#226 (PR) - Allow ordered lists to start from any number
+================================================================================
+
+* List item
+    0) Zero
+    1) One
+    2) Two
+
+* Backwards list
+    9) Nine
+    8) Eight
+
+--------------------------------------------------------------------------------
+
+(document
+  (section
+    (list
+      (list_item
+        (list_marker_star)
+        (paragraph
+          (inline)
+          (block_continuation))
+        (list
+          (list_item
+            (list_marker_parenthesis)
+            (paragraph
+              (inline)
+              (block_continuation)))
+          (list_item
+            (list_marker_parenthesis)
+            (paragraph
+              (inline)
+              (block_continuation)))
+          (list_item
+            (list_marker_parenthesis)
+            (paragraph
+              (inline)
+              (block_continuation)))))
+      (list_item
+        (list_marker_star)
+        (paragraph
+          (inline)
+          (block_continuation))
+        (list
+          (list_item
+            (list_marker_parenthesis)
+            (paragraph
+              (inline)
+              (block_continuation)))
+          (list_item
+            (list_marker_parenthesis)
+            (paragraph
+              (inline))))))))


### PR DESCRIPTION
Ordered lists that start from numbers other than 1 are not highlighted.

<img width="182" height="215" alt="image" src="https://github.com/user-attachments/assets/3d340e2b-f7b6-490e-8e8d-49dd0695e6db" />


I think it's reasonable to support this, e.g. VScode's default highlighting renders this as expected:
<img width="203" height="190" alt="image" src="https://github.com/user-attachments/assets/9b290c43-72b7-437e-861b-27284fc63632" />




