### PR TITLE
With `make`, install queries into conventionally named directories

### DIFF
--- a/common/common.mak
+++ b/common/common.mak
@@ -78,7 +78,7 @@ $(PARSER): $(SRC_DIR)/grammar.json
 	$(TS) generate $^
 
 install: all
-	install -d '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(LANGUAGE_NAME) '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'
+	install -d '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(LANGUAGE_UNPREFIXED_NAME) '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter '$(DESTDIR)$(PCLIBDIR)' '$(DESTDIR)$(LIBDIR)'
 	install -m644 bindings/c/tree-sitter/$(LANGUAGE_NAME).h '$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h
 	install -m644 $(LANGUAGE_NAME).pc '$(DESTDIR)$(PCLIBDIR)'/$(LANGUAGE_NAME).pc
 	install -m644 lib$(LANGUAGE_NAME).a '$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).a
@@ -93,7 +93,7 @@ else
 	cd '$(DESTDIR)$(LIBDIR)' && ln -sf lib$(LANGUAGE_NAME).$(SOEXTVER_MAJOR) lib$(LANGUAGE_NAME).$(SOEXT)
 endif
 ifneq ($(wildcard queries/*.scm),)
-	install -m644 queries/*.scm '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(LANGUAGE_NAME)
+	install -m644 queries/*.scm '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(LANGUAGE_UNPREFIXED_NAME)
 endif
 
 uninstall:
@@ -103,7 +103,7 @@ uninstall:
 		'$(DESTDIR)$(LIBDIR)'/lib$(LANGUAGE_NAME).$(SOEXT) \
 		'$(DESTDIR)$(INCLUDEDIR)'/tree_sitter/$(LANGUAGE_NAME).h \
 		'$(DESTDIR)$(PCLIBDIR)'/$(LANGUAGE_NAME).pc
-	$(RM) -r '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(LANGUAGE_NAME)
+	$(RM) -r '$(DESTDIR)$(DATADIR)'/tree-sitter/queries/$(LANGUAGE_UNPREFIXED_NAME)
 
 clean:
 	$(RM) $(OBJS) $(LANGUAGE_NAME).pc lib$(LANGUAGE_NAME).a lib$(LANGUAGE_NAME).$(SOEXT) lib$(LANGUAGE_NAME).dll.a

--- a/tree-sitter-markdown-inline/Makefile
+++ b/tree-sitter-markdown-inline/Makefile
@@ -1,3 +1,4 @@
 LANGUAGE_NAME := tree-sitter-markdown-inline
+LANGUAGE_UNPREFIXED_NAME := markdown-inline
 
 include ../common/common.mak

--- a/tree-sitter-markdown/Makefile
+++ b/tree-sitter-markdown/Makefile
@@ -1,4 +1,5 @@
 LANGUAGE_NAME := tree-sitter-markdown
+LANGUAGE_UNPREFIXED_NAME := markdown
 
 REQUIRES := tree-sitter-markdown-inline
 


### PR DESCRIPTION
It is typical to install queries into a directory named simply, e.g., `/usr/share/tree-sitter/queries/markdown`, rather than one named `/usr/share/tree-sitter/queries/tree-sitter-markdown`.