### PR TITLE
Remove junk `Requires: @TS_REQUIRES@` in `tree-sitter-markdown*.pc`

### DIFF
--- a/tree-sitter-markdown-inline/bindings/c/tree-sitter-markdown-inline.pc.in
+++ b/tree-sitter-markdown-inline/bindings/c/tree-sitter-markdown-inline.pc.in
@@ -6,6 +6,5 @@ Name: tree-sitter-markdown-inline
 Description: @PROJECT_DESCRIPTION@
 URL: @PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Requires: @TS_REQUIRES@
 Libs: -L${libdir} -ltree-sitter-markdown-inline
 Cflags: -I${includedir}

--- a/tree-sitter-markdown/bindings/c/tree-sitter-markdown.pc.in
+++ b/tree-sitter-markdown/bindings/c/tree-sitter-markdown.pc.in
@@ -6,6 +6,5 @@ Name: tree-sitter-markdown
 Description: @PROJECT_DESCRIPTION@
 URL: @PROJECT_HOMEPAGE_URL@
 Version: @PROJECT_VERSION@
-Requires: @TS_REQUIRES@
 Libs: -L${libdir} -ltree-sitter-markdown
 Cflags: -I${includedir}


### PR DESCRIPTION
Unlike the other entries in the pkg-config files, nothing replaces `@TS_REQUIRES@` with the actual value, causing, e.g., https://bugzilla.redhat.com/show_bug.cgi?id=2476879